### PR TITLE
Remove API namespace

### DIFF
--- a/src/ControlD.php
+++ b/src/ControlD.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rapkis\Controld\Api;
+namespace Rapkis\Controld;
 
 use Illuminate\Http\Client\PendingRequest;
 

--- a/src/ControlDFactory.php
+++ b/src/ControlDFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rapkis\Controld\Api;
+namespace Rapkis\Controld;
 
 use Illuminate\Config\Repository;
 use Illuminate\Http\Client\PendingRequest;

--- a/src/ControldServiceProvider.php
+++ b/src/ControldServiceProvider.php
@@ -3,8 +3,6 @@
 namespace Rapkis\Controld;
 
 use Illuminate\Contracts\Foundation\Application;
-use Rapkis\Controld\Api\ControlD;
-use Rapkis\Controld\Api\ControlDFactory;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 

--- a/src/RetryCallback.php
+++ b/src/RetryCallback.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rapkis\Controld\Api;
+namespace Rapkis\Controld;
 
 use Illuminate\Http\Client\ConnectionException;
 use Throwable;

--- a/tests/ControlDFactoryTest.php
+++ b/tests/ControlDFactoryTest.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Config\Repository;
 use Illuminate\Http\Client\PendingRequest;
-use Rapkis\Controld\Api\ControlDFactory;
-use Rapkis\Controld\Api\RetryCallback;
-use Rapkis\Controld\Tests\Api\TestMiddleware;
+use Rapkis\Controld\ControlDFactory;
+use Rapkis\Controld\RetryCallback;
+use Rapkis\Controld\Tests\Middleware\TestMiddleware;
 
 it('creates an api client', function () {
     $config = app(Repository::class);

--- a/tests/Middleware/TestMiddleware.php
+++ b/tests/Middleware/TestMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rapkis\Controld\Tests\Api;
+namespace Rapkis\Controld\Tests\Middleware;
 
 use Closure;
 use Psr\Http\Message\RequestInterface;

--- a/tests/RetryCallbackTest.php
+++ b/tests/RetryCallbackTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Client\ConnectionException;
-use Rapkis\Controld\Api\RetryCallback;
+use Rapkis\Controld\RetryCallback;
 
 it('will retry for exception', function (Throwable $exception, bool $willRetry) {
     $retry = new RetryCallback();


### PR DESCRIPTION
- Move main classes to the root namespace
- Move TestMiddleware.php to a separate Tests\Middleware namespace