### PR TITLE
Implement the Profiles API endpoints

### DIFF
--- a/src/ControlD.php
+++ b/src/ControlD.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace Rapkis\Controld;
 
 use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\Resources\Profiles;
 
 class ControlD
 {
     public function __construct(private PendingRequest $request)
     {
+    }
+
+    public function profiles(): Profiles
+    {
+        return app(Profiles::class, ['client' => $this->request]);
     }
 }

--- a/src/Entities/ProfileFilters.php
+++ b/src/Entities/ProfileFilters.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Entities;
+
+/** TODO
+ * these filters are poorly documented and it is not
+ * always clear what they stand for or what data
+ * they carry within
+ */
+class ProfileFilters
+{
+    public function __construct(
+        public readonly array $flt,
+        public readonly array $cflt,
+        public readonly array $ipflt,
+        public readonly array $rule,
+        public readonly array $svc,
+        public readonly array $grp,
+        public readonly array $opt,
+        public readonly array $da,
+    ) {
+    }
+}

--- a/src/Entities/ProfileOption.php
+++ b/src/Entities/ProfileOption.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Entities;
+
+class ProfileOption
+{
+    public function __construct(
+        public readonly string $pk,
+        public readonly string $title,
+        public readonly string $description,
+        public readonly string $type,
+        public readonly mixed $default,
+        public readonly string $infoUrl,
+    ) {
+    }
+}

--- a/src/Factories/ProfileFactory.php
+++ b/src/Factories/ProfileFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Factories;
+
+use Rapkis\Controld\Responses\Profile;
+use Rapkis\Controld\Entities\ProfileFilters;
+
+class ProfileFactory
+{
+    public function make(array $profile): Profile
+    {
+        return new Profile(
+            pk: $profile['PK'],
+            updated: $profile['updated'],
+            name: $profile['name'],
+            disableTtl: $profile['disable_ttl'] ?? null,
+            stats: $profile['stats'] ?? null,
+            filters: new ProfileFilters(
+                flt: $profile['profile']['flt'],
+                cflt: $profile['profile']['cflt'],
+                ipflt: $profile['profile']['ipflt'],
+                rule: $profile['profile']['rule'],
+                svc: $profile['profile']['svc'],
+                grp: $profile['profile']['grp'],
+                opt: $profile['profile']['opt'],
+                da: $profile['profile']['da'],
+            )
+        );
+    }
+}

--- a/src/Factories/ProfileFactory.php
+++ b/src/Factories/ProfileFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rapkis\Controld\Factories;
 
-use Rapkis\Controld\Responses\Profile;
 use Rapkis\Controld\Entities\ProfileFilters;
+use Rapkis\Controld\Responses\Profile;
 
 class ProfileFactory
 {

--- a/src/Factories/ProfileOptionFactory.php
+++ b/src/Factories/ProfileOptionFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Factories;
+
+use Rapkis\Controld\Entities\ProfileOption;
+
+class ProfileOptionFactory
+{
+    public function make(array $data): ProfileOption
+    {
+        if ($data['type'] === 'toggle') {
+            $data['default_value'] = (bool) $data['default_value'];
+        }
+
+        return new ProfileOption(
+            pk: $data['PK'],
+            title: $data['title'],
+            description: $data['description'],
+            type: $data['type'],
+            default: $data['default_value'],
+            infoUrl: $data['info_url'],
+        );
+    }
+}

--- a/src/Resources/Profiles.php
+++ b/src/Resources/Profiles.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Resources;
+
+use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\Responses\Profile;
+use Rapkis\Controld\Factories\ProfileFactory;
+use Rapkis\Controld\Factories\ProfileOptionFactory;
+use Rapkis\Controld\Responses\ProfileList;
+use Rapkis\Controld\Responses\ProfileOptions;
+
+class Profiles
+{
+    public function __construct(
+        private PendingRequest $client,
+        private ProfileFactory $profile,
+        private ProfileOptionFactory $option,
+    ) {
+    }
+
+    public function list(): ProfileList
+    {
+        $response = $this->client->get('profiles')->json('body.profiles');
+
+        $result = new ProfileList();
+
+        foreach ($response as $profile) {
+            $profile = $this->profile->make($profile);
+            $result->put($profile->pk, $profile);
+        }
+
+        return $result;
+    }
+
+    public function create(string $name, string $cloneProfileId = null): Profile
+    {
+        $profile = $this->client->post('profiles', [
+            'name' => $name,
+            'clone_profile_id' => $cloneProfileId,
+        ])->json('body.profiles.0');
+
+        return $this->profile->make($profile);
+    }
+
+    public function modify(string $profilePk, string $name = null, int $disableTtl = null): Profile
+    {
+        $profile = $this->client->post("profiles/{$profilePk}", [
+            'name' => $name,
+            'disable_tll' => $disableTtl,
+        ])->json('body.profiles.0');
+
+        return $this->profile->make($profile);
+    }
+
+    public function delete(string $profilePk): bool
+    {
+        $this->client->delete("profiles/{$profilePk}");
+
+        return true;
+    }
+
+    public function options(): ProfileOptions
+    {
+        $response = $this->client->get('profiles/options')->json('body.options');
+
+        $result = new ProfileOptions();
+
+        foreach ($response as $option) {
+            $option = $this->option->make($option);
+            $result->put($option->pk, $option);
+        }
+
+        return $result;
+    }
+
+    /**
+     * At the time of writing, ControlD only supports on/of values,
+     * even though ai_malware option does not accept those.
+     * This may change, after this experimental option is finalised.
+     */
+    public function modifyOption(string $profilePk, string $optionPk, bool $enable): bool
+    {
+        $this->client->put("profiles/{$profilePk}/options/{$optionPk}", [
+            'status' => (int) $enable,
+        ]);
+
+        return true;
+    }
+}

--- a/src/Resources/Profiles.php
+++ b/src/Resources/Profiles.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Rapkis\Controld\Resources;
 
 use Illuminate\Http\Client\PendingRequest;
-use Rapkis\Controld\Responses\Profile;
 use Rapkis\Controld\Factories\ProfileFactory;
 use Rapkis\Controld\Factories\ProfileOptionFactory;
+use Rapkis\Controld\Responses\Profile;
 use Rapkis\Controld\Responses\ProfileList;
 use Rapkis\Controld\Responses\ProfileOptions;
 

--- a/src/Responses/Profile.php
+++ b/src/Responses/Profile.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Responses;
+
+use Rapkis\Controld\Entities\ProfileFilters;
+
+class Profile
+{
+    public function __construct(
+        public readonly string $pk,
+        public readonly int $updated,
+        public readonly string $name,
+        public readonly ?int $disableTtl,
+        public readonly ?int $stats,
+        public readonly ProfileFilters $filters,
+    ) {
+    }
+}

--- a/src/Responses/ProfileList.php
+++ b/src/Responses/ProfileList.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Responses;
+
+use Illuminate\Support\Collection;
+
+class ProfileList extends Collection
+{
+}

--- a/src/Responses/ProfileOptions.php
+++ b/src/Responses/ProfileOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Responses;
+
+use Illuminate\Support\Collection;
+
+class ProfileOptions extends Collection
+{
+}

--- a/tests/ControlDTest.php
+++ b/tests/ControlDTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\ControlD;
+use Rapkis\Controld\Resources\Profiles;
+
+it('accesses profiles resource', function () {
+    $client = new ControlD($this->createStub(PendingRequest::class));
+    expect($client->profiles())->toBeInstanceOf(Profiles::class);
+});

--- a/tests/Factories/ProfileFactoryTest.php
+++ b/tests/Factories/ProfileFactoryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Rapkis\Controld\Responses\Profile;
 use Rapkis\Controld\Entities\ProfileFilters;
 use Rapkis\Controld\Factories\ProfileFactory;
+use Rapkis\Controld\Responses\Profile;
 
 it('builds a profile', function (array $data, Profile $expected) {
     expect((new ProfileFactory())->make($data))->toEqual($expected);

--- a/tests/Factories/ProfileFactoryTest.php
+++ b/tests/Factories/ProfileFactoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Rapkis\Controld\Responses\Profile;
+use Rapkis\Controld\Entities\ProfileFilters;
+use Rapkis\Controld\Factories\ProfileFactory;
+
+it('builds a profile', function (array $data, Profile $expected) {
+    expect((new ProfileFactory())->make($data))->toEqual($expected);
+})->with([
+    [
+        [
+            'PK' => '123test123',
+            'updated' => 111111111,
+            'name' => 'Test',
+            'profile' => [
+                'flt' => ['count' => 3],
+                'cflt' => ['count' => 0],
+                'ipflt' => ['count' => 0],
+                'rule' => ['count' => 0],
+                'svc' => ['count' => 1],
+                'grp' => ['count' => 0],
+                'opt' => [
+                    'count' => 0,
+                    'data' => [],
+                ],
+                'da' => [],
+            ],
+        ],
+        new Profile(
+            pk: '123test123',
+            updated: 111111111,
+            name: 'Test',
+            disableTtl: null,
+            stats: null,
+            filters: new ProfileFilters(
+                flt: ['count' => 3],
+                cflt: ['count' => 0],
+                ipflt: ['count' => 0],
+                rule: ['count' => 0],
+                svc: ['count' => 1],
+                grp: ['count' => 0],
+                opt: [
+                    'count' => 0,
+                    'data' => [],
+                ],
+                da: [],
+            )
+        ),
+    ],
+    [
+        [
+            'PK' => '123test123',
+            'updated' => 111111111,
+            'name' => 'Test',
+            'disable_ttl' => 1695971151,
+            'stats' => 1,
+            'profile' => [
+                'flt' => ['count' => 3],
+                'cflt' => ['count' => 0],
+                'ipflt' => ['count' => 0],
+                'rule' => ['count' => 0],
+                'svc' => ['count' => 1],
+                'grp' => ['count' => 0],
+                'opt' => [
+                    'count' => 0,
+                    'data' => [],
+                ],
+                'da' => [],
+            ],
+        ],
+        new Profile(
+            pk: '123test123',
+            updated: 111111111,
+            name: 'Test',
+            disableTtl: 1695971151,
+            stats: 1,
+            filters: new ProfileFilters(
+                flt: ['count' => 3],
+                cflt: ['count' => 0],
+                ipflt: ['count' => 0],
+                rule: ['count' => 0],
+                svc: ['count' => 1],
+                grp: ['count' => 0],
+                opt: [
+                    'count' => 0,
+                    'data' => [],
+                ],
+                da: [],
+            )
+        ),
+    ],
+]);

--- a/tests/Factories/ProfileOptionFactoryTest.php
+++ b/tests/Factories/ProfileOptionFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use Rapkis\Controld\Entities\ProfileOption;
+use Rapkis\Controld\Factories\ProfileOptionFactory;
+
+it('builds a profile option', function (array $data, ProfileOption $expected) {
+    expect((new ProfileOptionFactory())->make($data))->toEqual($expected);
+})->with([
+    [
+        [
+            'PK' => 'block_foo_false',
+            'title' => 'This is a toggle option',
+            'description' => 'This set represents an option that can be toggled',
+            'type' => 'toggle',
+            'default_value' => 0,
+            'info_url' => 'https://example.com',
+        ],
+        new ProfileOption(
+            pk: 'block_foo_false',
+            title: 'This is a toggle option',
+            description: 'This set represents an option that can be toggled',
+            type: 'toggle',
+            default: false,
+            infoUrl: 'https://example.com',
+        ),
+    ],
+    [
+        [
+            'PK' => 'block_bar_true',
+            'title' => 'This is a toggle option',
+            'description' => 'This set represents an option that can be toggled. It is on by default',
+            'type' => 'toggle',
+            'default_value' => 1,
+            'info_url' => 'https://example.com',
+        ],
+        new ProfileOption(
+            pk: 'block_bar_true',
+            title: 'This is a toggle option',
+            description: 'This set represents an option that can be toggled. It is on by default',
+            type: 'toggle',
+            default: true,
+            infoUrl: 'https://example.com',
+        ),
+    ],
+    [
+        [
+            'PK' => 'dropdown_multiple',
+            'title' => 'This is a dropdown option',
+            'description' => 'This set represents an option can have multiple values',
+            'type' => 'dropdown',
+            'default_value' => [],
+            'info_url' => 'https://example.com',
+        ],
+        new ProfileOption(
+            pk: 'dropdown_multiple',
+            title: 'This is a dropdown option',
+            description: 'This set represents an option can have multiple values',
+            type: 'dropdown',
+            default: [],
+            infoUrl: 'https://example.com',
+        ),
+    ],
+    [
+        [
+            'PK' => 'dropdown_multiple_with_options',
+            'title' => 'This is a dropdown option',
+            'description' => 'This set represents an option can have multiple values. It has default values',
+            'type' => 'dropdown',
+            'default_value' => [
+                '0.9' => 'Zero point nine',
+                1 => 'Number one',
+            ],
+            'info_url' => 'https://example.com',
+        ],
+        new ProfileOption(
+            pk: 'dropdown_multiple_with_options',
+            title: 'This is a dropdown option',
+            description: 'This set represents an option can have multiple values. It has default values',
+            type: 'dropdown',
+            default: [
+                '0.9' => 'Zero point nine',
+                1 => 'Number one',
+            ],
+            infoUrl: 'https://example.com',
+        ),
+    ],
+    [
+        [
+            'PK' => 'input_field_option',
+            'title' => 'This is an option with user input',
+            'description' => 'This set represents an option that can modified by the user',
+            'type' => 'field',
+            'default_value' => 1,
+            'info_url' => 'https://example.com',
+        ],
+        new ProfileOption(
+            pk: 'input_field_option',
+            title: 'This is an option with user input',
+            description: 'This set represents an option that can modified by the user',
+            type: 'field',
+            default: 1,
+            infoUrl: 'https://example.com',
+        ),
+    ],
+]);
+
+it('casts boolean values', function () {
+    $option = (new ProfileOptionFactory())->make([
+        'PK' => 'block_foo_false',
+        'title' => 'This is a toggle option',
+        'description' => 'This set represents an option that can be toggled',
+        'type' => 'toggle',
+        'default_value' => 0,
+        'info_url' => 'https://example.com',
+    ]);
+
+    expect($option->default)->toBeFalse();
+
+    $option = (new ProfileOptionFactory())->make([
+        'PK' => 'block_bar_true',
+        'title' => 'This is a toggle option',
+        'description' => 'This set represents an option that can be toggled. It is on by default',
+        'type' => 'toggle',
+        'default_value' => 1,
+        'info_url' => 'https://example.com',
+    ]);
+
+    expect($option->default)->toBeTrue();
+});

--- a/tests/Mocks/Endpoints/profiles-create.json
+++ b/tests/Mocks/Endpoints/profiles-create.json
@@ -1,0 +1,38 @@
+{
+    "body": {
+        "profiles": [
+            {
+                "PK": "123test123",
+                "updated": 111111111,
+                "name": "Test",
+                "profile": {
+                    "flt": {
+                        "count": 3
+                    },
+                    "cflt": {
+                        "count": 0
+                    },
+                    "ipflt": {
+                        "count": 0
+                    },
+                    "rule": {
+                        "count": 0
+                    },
+                    "svc": {
+                        "count": 1
+                    },
+                    "grp": {
+                        "count": 0
+                    },
+                    "opt": {
+                        "count": 0,
+                        "data": []
+                    },
+                    "da": []
+                }
+            }
+        ]
+    },
+    "success": true,
+    "message": "Profile has been created"
+}

--- a/tests/Mocks/Endpoints/profiles-delete.json
+++ b/tests/Mocks/Endpoints/profiles-delete.json
@@ -1,0 +1,5 @@
+{
+    "body": [],
+    "success": true,
+    "message": "Profile has been deleted"
+}

--- a/tests/Mocks/Endpoints/profiles-list-options.json
+++ b/tests/Mocks/Endpoints/profiles-list-options.json
@@ -1,0 +1,83 @@
+{
+    "body": {
+        "options": [
+            {
+                "PK": "block_rfc1918",
+                "title": "DNS Rebind Protection",
+                "description": "Blocks domains that point to RFC1918 addresses.",
+                "type": "toggle",
+                "default_value": 0,
+                "info_url": "https://docs.controld.com/docs/dns-rebind-option"
+            },
+            {
+                "PK": "spoof_ipv6",
+                "title": "IPv4/IPv6 Compatibility Mode",
+                "description": "Redirect A records via IPv6 resolver and vice versa.",
+                "type": "toggle",
+                "default_value": 0,
+                "info_url": "https://docs.controld.com/docs/ipv6-compatibility-mode"
+            },
+            {
+                "PK": "no_dnssec",
+                "title": "Disable DNSSEC",
+                "description": "Turn off DNSSEC validation and ECS support for compatibility.",
+                "type": "toggle",
+                "default_value": 0,
+                "info_url": "https://docs.controld.com/docs/disable-dnssec-option"
+            },
+            {
+                "PK": "ai_malware",
+                "title": "AI Malware Filter",
+                "description": "EXPERIMENTAL: Blocks malicious domains using machine learning.",
+                "type": "dropdown",
+                "default_value": {
+                    "0.9": "Relaxed Mode",
+                    "0.7": "Balanced Mode",
+                    "0.5": "Strict Mode"
+                },
+                "info_url": "https://docs.controld.com/docs/ai-malware-filter"
+            },
+            {
+                "PK": "ttl_blck",
+                "title": "Block TTL",
+                "description": "DNS record TTL (in seconds) when blocking.",
+                "type": "field",
+                "default_value": 10,
+                "info_url": "https://docs.controld.com/docs/ttl-overrides"
+            },
+            {
+                "PK": "ttl_spff",
+                "title": "Redirect TTL",
+                "description": "DNS record TTL (in seconds) when redirecting.",
+                "type": "field",
+                "default_value": 20,
+                "info_url": "https://docs.controld.com/docs/ttl-overrides"
+            },
+            {
+                "PK": "ttl_pass",
+                "title": "Bypass TTL",
+                "description": "DNS record TTL (in seconds) when bypassing.",
+                "type": "field",
+                "default_value": 60,
+                "info_url": "https://docs.controld.com/docs/ttl-overrides"
+            },
+            {
+                "PK": "safesearch",
+                "title": "Safe Search",
+                "description": "Prevent search engines from showing mature content.",
+                "type": "toggle",
+                "default_value": 0,
+                "info_url": "https://docs.controld.com/docs/safe-search"
+            },
+            {
+                "PK": "safeyoutube",
+                "title": "Restricted Youtube",
+                "description": "Prevent Youtube from showing mature content and disable comments.",
+                "type": "toggle",
+                "default_value": 0,
+                "info_url": "https://docs.controld.com/docs/restricted-youtube"
+            }
+        ]
+    },
+    "success": true
+}

--- a/tests/Mocks/Endpoints/profiles-list.json
+++ b/tests/Mocks/Endpoints/profiles-list.json
@@ -1,0 +1,67 @@
+{
+    "body": {
+        "profiles": [
+            {
+                "PK": "123test123",
+                "updated": 111111111,
+                "name": "Foo",
+                "profile": {
+                    "flt": {
+                        "count": 3
+                    },
+                    "cflt": {
+                        "count": 0
+                    },
+                    "ipflt": {
+                        "count": 0
+                    },
+                    "rule": {
+                        "count": 0
+                    },
+                    "svc": {
+                        "count": 1
+                    },
+                    "grp": {
+                        "count": 0
+                    },
+                    "opt": {
+                        "count": 0,
+                        "data": []
+                    },
+                    "da": []
+                }
+            },
+            {
+                "PK": "123foobar",
+                "updated": 222222222,
+                "name": "Bar",
+                "profile": {
+                    "flt": {
+                        "count": 0
+                    },
+                    "cflt": {
+                        "count": 0
+                    },
+                    "ipflt": {
+                        "count": 0
+                    },
+                    "rule": {
+                        "count": 0
+                    },
+                    "svc": {
+                        "count": 0
+                    },
+                    "grp": {
+                        "count": 0
+                    },
+                    "opt": {
+                        "count": 0,
+                        "data": []
+                    },
+                    "da": []
+                }
+            }
+        ]
+    },
+    "success": true
+}

--- a/tests/Mocks/Endpoints/profiles-modify-options.json
+++ b/tests/Mocks/Endpoints/profiles-modify-options.json
@@ -1,0 +1,11 @@
+{
+    "body": {
+        "options": [
+            {
+                "PK": "option_pk",
+                "value": 0
+            }
+        ]
+    },
+    "success": true
+}

--- a/tests/Mocks/Endpoints/profiles-modify.json
+++ b/tests/Mocks/Endpoints/profiles-modify.json
@@ -1,0 +1,39 @@
+{
+  "body": {
+    "profiles": [
+      {
+        "PK": "123foobar",
+        "updated": 111111111,
+        "name": "Foo",
+        "disable_ttl": 1693303746,
+        "profile": {
+          "flt": {
+            "count": 0
+          },
+          "cflt": {
+            "count": 0
+          },
+          "ipflt": {
+            "count": 0
+          },
+          "rule": {
+            "count": 0
+          },
+          "svc": {
+            "count": 0
+          },
+          "grp": {
+            "count": 0
+          },
+          "opt": {
+            "count": 0,
+            "data": []
+          },
+          "da": []
+        }
+      }
+    ]
+  },
+  "success": true,
+  "message": "Profile has been updated"
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,3 +3,8 @@
 use Rapkis\Controld\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
+
+function mockJsonEndpoint(string $endpoint): string
+{
+    return file_get_contents(__DIR__."/Mocks/Endpoints/{$endpoint}.json");
+}

--- a/tests/Resources/ProfilesTest.php
+++ b/tests/Resources/ProfilesTest.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
-use Rapkis\Controld\Responses\Profile;
 use Rapkis\Controld\Factories\ProfileFactory;
 use Rapkis\Controld\Factories\ProfileOptionFactory;
 use Rapkis\Controld\Resources\Profiles;
+use Rapkis\Controld\Responses\Profile;
 use Rapkis\Controld\Responses\ProfileList;
 use Rapkis\Controld\Responses\ProfileOptions;
 

--- a/tests/Resources/ProfilesTest.php
+++ b/tests/Resources/ProfilesTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Rapkis\Controld\Responses\Profile;
+use Rapkis\Controld\Factories\ProfileFactory;
+use Rapkis\Controld\Factories\ProfileOptionFactory;
+use Rapkis\Controld\Resources\Profiles;
+use Rapkis\Controld\Responses\ProfileList;
+use Rapkis\Controld\Responses\ProfileOptions;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('lists profiles', function () {
+    $request = Http::fake([
+        'profiles' => Http::response(mockJsonEndpoint('profiles-list')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        app(ProfileFactory::class),
+        $this->createStub(ProfileOptionFactory::class),
+    );
+
+    $result = $resource->list();
+
+    expect($result)->toBeInstanceOf(ProfileList::class)
+        ->and($result)->toHaveCount(2);
+});
+
+it('creates a profile', function () {
+    $request = Http::fake([
+        'profiles' => Http::response(mockJsonEndpoint('profiles-create')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        app(ProfileFactory::class),
+        $this->createStub(ProfileOptionFactory::class),
+    );
+
+    $result = $resource->create('Test name');
+
+    expect($result)->toBeInstanceOf(Profile::class);
+});
+
+it('modifies a profile', function () {
+    $request = Http::fake([
+        'profiles/123foobar' => Http::response(mockJsonEndpoint('profiles-modify')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        app(ProfileFactory::class),
+        $this->createStub(ProfileOptionFactory::class),
+    );
+
+    $result = $resource->modify('123foobar');
+
+    expect($result)->toBeInstanceOf(Profile::class);
+});
+
+it('deletes a profile', function () {
+    $request = Http::fake([
+        'profiles/123foobar' => Http::response(mockJsonEndpoint('profiles-delete')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        app(ProfileFactory::class),
+        $this->createStub(ProfileOptionFactory::class),
+    );
+
+    $result = $resource->delete('123foobar');
+
+    expect($result)->toBeTrue();
+});
+
+it('lists profile options', function () {
+    $request = Http::fake([
+        'profiles/options' => Http::response(mockJsonEndpoint('profiles-list-options')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        $this->createStub(ProfileFactory::class),
+        app(ProfileOptionFactory::class),
+    );
+
+    $result = $resource->options();
+
+    expect($result)->toBeInstanceOf(ProfileOptions::class)
+        ->and($result)->toHaveCount(9);
+});
+
+it('can modify profile option', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/options/option_pk' => Http::response(mockJsonEndpoint('profiles-modify-options')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        $this->createStub(ProfileFactory::class),
+        $this->createStub(ProfileOptionFactory::class),
+    );
+
+    expect($resource->modifyOption('profile_pk', 'option_pk', true))->toBeTrue();
+});


### PR DESCRIPTION
- ControlD method profiles() returns a separate Profile resource class
- The resource class makes HTTP requests and creates responses
- Responses are objects or booleans to ensure the response structure is known. Arrays should not be used, as they are difficult to work with
- The actual HTTP response parsing is done in factory classes to avoid code duplication and enforce separation of concerns
- Introduced Entity classes, which are simple objects nested within Response classes
- Introduced mocked json responses to feature test the HTTP request handling
- Added a helper method mockJsonEndpoint to Pest.php in order to conveniently use said responses