### PR TITLE
Implement profile services endpoints

### DIFF
--- a/src/Entities/Service.php
+++ b/src/Entities/Service.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Entities;
+
+class Service
+{
+    public function __construct(
+        public readonly string $pk,
+        public readonly string $category,
+        public readonly string $name,
+        public readonly string $unlockLocation,
+        public readonly array $locations,
+        public readonly ?string $warning,
+        public readonly ?ServiceAction $action,
+    ) {
+    }
+}

--- a/src/Entities/ServiceAction.php
+++ b/src/Entities/ServiceAction.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Entities;
+
+use InvalidArgumentException;
+
+class ServiceAction
+{
+    public function __construct(
+        public readonly int $do,
+        public readonly bool $status,
+        public readonly ?string $via,
+    ) {
+        //        if ($this->do < 0 || $this->do > 3) {
+        //            throw new InvalidArgumentException("Argument 'do' must be between 0 and 3");
+        //        }
+    }
+}

--- a/src/Factories/ServiceFactory.php
+++ b/src/Factories/ServiceFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Factories;
+
+use Rapkis\Controld\Contracts\Factories\Factory;
+use Rapkis\Controld\Entities\Service;
+use Rapkis\Controld\Entities\ServiceAction;
+
+class ServiceFactory implements Factory
+{
+    public function make(array $data): Service
+    {
+        if (! empty($data['action'])) {
+            $action = new ServiceAction(
+                do: $data['action']['do'],
+                status: (bool) $data['action']['status'],
+                via: $data['action']['via'] ?? null,
+            );
+        }
+
+        return new Service(
+            pk: $data['PK'],
+            category: $data['category'],
+            name: $data['name'],
+            unlockLocation: $data['unlock_location'],
+            locations: $data['locations'] ?? [],
+            warning: $data['warning'] ?? null,
+            action: $action ?? null,
+        );
+    }
+}

--- a/src/Responses/Services.php
+++ b/src/Responses/Services.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Responses;
+
+use Illuminate\Support\Collection;
+
+class Services extends Collection
+{
+}

--- a/tests/Factories/ServiceFactoryTest.php
+++ b/tests/Factories/ServiceFactoryTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use Rapkis\Controld\Entities\Service;
+use Rapkis\Controld\Entities\ServiceAction;
+use Rapkis\Controld\Factories\ServiceFactory;
+
+it('builds a service', function (array $data, Service $expected) {
+    expect((new ServiceFactory())->make($data))->toEqual($expected);
+})->with([
+    [
+        [
+            'PK' => 'no_action',
+            'category' => 'tools',
+            'name' => 'No action from List All Services endpoint',
+            'unlock_location' => 'JFK',
+        ],
+        new Service(
+            pk: 'no_action',
+            category: 'tools',
+            name: 'No action from List All Services endpoint',
+            unlockLocation: 'JFK',
+            locations: [],
+            warning: null,
+            action: null,
+        ),
+    ],
+    [
+        [
+            'PK' => 'block_disabled',
+            'category' => 'social',
+            'name' => 'Facebook',
+            'unlock_location' => 'JFK',
+            'locations' => [],
+            'warning' => 'foo',
+            'action' => [
+                'do' => 0,
+                'status' => 0,
+            ],
+        ],
+        new Service(
+            pk: 'block_disabled',
+            category: 'social',
+            name: 'Facebook',
+            unlockLocation: 'JFK',
+            locations: [],
+            warning: 'foo',
+            action: new ServiceAction(
+                do: 0,
+                status: false,
+                via: null,
+            ),
+        ),
+    ],
+    [
+        [
+            'PK' => 'bypass_enabled',
+            'category' => '',
+            'name' => '',
+            'unlock_location' => 'JFK',
+            'locations' => [],
+            'action' => [
+                'do' => 1,
+                'status' => 1,
+            ],
+        ],
+        new Service(
+            pk: 'bypass_enabled',
+            category: '',
+            name: '',
+            unlockLocation: 'JFK',
+            locations: [],
+            warning: null,
+            action: new ServiceAction(
+                do: 1,
+                status: true,
+                via: null,
+            ),
+        ),
+    ],
+    [
+        [
+            'PK' => 'spoof',
+            'category' => '',
+            'name' => '',
+            'unlock_location' => 'JFK',
+            'locations' => [],
+            'action' => [
+                'do' => 2,
+                'status' => 0,
+            ],
+        ],
+        new Service(
+            pk: 'spoof',
+            category: '',
+            name: '',
+            unlockLocation: 'JFK',
+            locations: [],
+            warning: null,
+            action: new ServiceAction(
+                do: 2,
+                status: false,
+                via: null,
+            ),
+        ),
+    ],
+    [
+        [
+            'PK' => 'redirect_proxy',
+            'category' => '',
+            'name' => '',
+            'unlock_location' => 'JFK',
+            'locations' => ['FOO', 'BAR'],
+            'action' => [
+                'do' => 3,
+                'status' => 0,
+                'via' => 'CITY',
+            ],
+        ],
+        new Service(
+            pk: 'redirect_proxy',
+            category: '',
+            name: '',
+            unlockLocation: 'JFK',
+            locations: ['FOO', 'BAR'],
+            warning: null,
+            action: new ServiceAction(
+                do: 3,
+                status: false,
+                via: 'CITY',
+            ),
+        ),
+    ],
+]);

--- a/tests/Mocks/Endpoints/profiles-services-list.json
+++ b/tests/Mocks/Endpoints/profiles-services-list.json
@@ -1,0 +1,54 @@
+{
+    "body": {
+        "services": [
+            {
+                "category": "video",
+                "name": "BBC iPlayer",
+                "locations": [
+                    "LHR",
+                    "EDI",
+                    "MAN"
+                ],
+                "unlock_location": "LHR",
+                "PK": "iplayer",
+                "action": {
+                    "do": 3,
+                    "via": "LHR",
+                    "status": 0
+                }
+            },
+            {
+                "name": "Facebook",
+                "unlock_location": "JFK",
+                "category": "social",
+                "PK": "facebook",
+                "action": {
+                    "do": 0,
+                    "status": 0
+                }
+            },
+            {
+                "name": "Prime Video",
+                "unlock_location": "JFK",
+                "category": "video",
+                "PK": "primevideo",
+                "action": {
+                    "do": 1,
+                    "status": 0
+                }
+            },
+            {
+                "name": "Youtube",
+                "unlock_location": "DFW",
+                "category": "video",
+                "PK": "youtube",
+                "action": {
+                    "do": 3,
+                    "via": "KIV",
+                    "status": 1
+                }
+            }
+        ]
+    },
+    "success": true
+}

--- a/tests/Mocks/Endpoints/profiles-services-modify.json
+++ b/tests/Mocks/Endpoints/profiles-services-modify.json
@@ -1,0 +1,11 @@
+{
+    "body": {
+        "services": [
+            {
+                "do": 0,
+                "status": 1
+            }
+        ]
+    },
+    "success": true
+}

--- a/tests/Resources/ProfilesTest.php
+++ b/tests/Resources/ProfilesTest.php
@@ -3,14 +3,17 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
+use Rapkis\Controld\Entities\ServiceAction;
 use Rapkis\Controld\Factories\FilterFactory;
 use Rapkis\Controld\Factories\ProfileFactory;
 use Rapkis\Controld\Factories\ProfileOptionFactory;
+use Rapkis\Controld\Factories\ServiceFactory;
 use Rapkis\Controld\Resources\Profiles;
 use Rapkis\Controld\Responses\Filters;
 use Rapkis\Controld\Responses\Profile;
 use Rapkis\Controld\Responses\ProfileList;
 use Rapkis\Controld\Responses\ProfileOptions;
+use Rapkis\Controld\Responses\Services;
 
 beforeEach(function () {
     Http::preventStrayRequests();
@@ -26,6 +29,7 @@ it('lists profiles', function () {
         app(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->list();
@@ -44,6 +48,7 @@ it('creates a profile', function () {
         app(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->create('Test name');
@@ -61,6 +66,7 @@ it('modifies a profile', function () {
         app(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->modify('123foobar');
@@ -78,6 +84,7 @@ it('deletes a profile', function () {
         app(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->delete('123foobar');
@@ -95,6 +102,7 @@ it('lists profile options', function () {
         $this->createStub(ProfileFactory::class),
         app(ProfileOptionFactory::class),
         $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->options();
@@ -113,6 +121,7 @@ it('can modify profile option', function () {
         $this->createStub(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     expect($resource->modifyOption('profile_pk', 'option_pk', true))->toBeTrue();
@@ -128,6 +137,7 @@ it('lists native profile filters', function () {
         $this->createStub(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         app(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->listNativeFilters('profile_pk');
@@ -146,6 +156,7 @@ it('lists third party profile filters', function () {
         $this->createStub(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         app(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->listThirdPartyFilters('profile_pk');
@@ -164,6 +175,7 @@ it('modifies a filter for a profile', function () {
         $this->createStub(ProfileFactory::class),
         $this->createStub(ProfileOptionFactory::class),
         $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
     );
 
     $result = $resource->modifyFilters('profile_pk', 'ads', true);
@@ -172,4 +184,45 @@ it('modifies a filter for a profile', function () {
         ->and($result[0])->toEqual('ads')
         ->and($result[1])->toEqual('iot')
         ->and($result[2])->toEqual('malware');
+});
+
+it('lists profile services', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/services' => Http::response(mockJsonEndpoint('profiles-services-list')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        $this->createStub(ProfileFactory::class),
+        $this->createStub(ProfileOptionFactory::class),
+        $this->createStub(FilterFactory::class),
+        app(ServiceFactory::class),
+    );
+
+    $result = $resource->listServices('profile_pk');
+
+    expect($result)->toBeInstanceOf(Services::class)
+        ->and($result)->toHaveCount(4);
+});
+
+it('modifies a service for a profile', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/services/service' => Http::response(mockJsonEndpoint('profiles-services-modify')),
+    ])->asJson();
+
+    $resource = new Profiles(
+        $request,
+        $this->createStub(ProfileFactory::class),
+        $this->createStub(ProfileOptionFactory::class),
+        $this->createStub(FilterFactory::class),
+        $this->createStub(ServiceFactory::class),
+    );
+
+    $result = $resource->modifyService('profile_pk', 'service', new ServiceAction(
+        do: 0,
+        status: true,
+        via: null,
+    ));
+
+    expect($result)->toBeTrue();
 });


### PR DESCRIPTION
- One endpoint for retrieving the list and one for modifying a specific service for a profile
- The Service.php class represents the structure of a service
- It also has an optional ServiceAction.php property. This action is displayed when listing services for a profile. It is, however, nullable since listing ALL services (different API endpoint /services/categories/{category}) doesn't show the actions