### PR TITLE
Refactor code structure

### DIFF
--- a/src/Resources/Profiles/Filters.php
+++ b/src/Resources/Profiles/Filters.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Resources\Profiles;
+
+use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\Factories\FilterFactory;
+
+class Filters
+{
+    public function __construct(private readonly PendingRequest $client, private readonly FilterFactory $filter)
+    {
+    }
+
+    public function native(string $profilePk): \Rapkis\Controld\Responses\Filters
+    {
+        $response = $this->client->get("profiles/{$profilePk}/filters")->json('body.filters');
+
+        $result = new \Rapkis\Controld\Responses\Filters();
+
+        foreach ($response as $filter) {
+            $filter = $this->filter->make($filter);
+            $result[$filter->pk] = $filter;
+        }
+
+        return $result;
+    }
+
+    public function thirdParty(string $profilePk): \Rapkis\Controld\Responses\Filters
+    {
+        $response = $this->client->get("profiles/{$profilePk}/filters/external")->json('body.filters');
+
+        $result = new \Rapkis\Controld\Responses\Filters();
+
+        foreach ($response as $filter) {
+            $filter = $this->filter->make($filter);
+            $result[$filter->pk] = $filter;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Enable or disable a filter for a profile.
+     * Returns a list of filter PKs
+     *
+     * @return array<string>
+     */
+    public function modify(string $profilePk, string $filterPk, bool $enable): array
+    {
+        return $this->client->put("profiles/{$profilePk}/filters/filter/{$filterPk}", ['status' => (int) $enable])
+            ->json('body.filters');
+    }
+}

--- a/src/Resources/Profiles/Options.php
+++ b/src/Resources/Profiles/Options.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Resources\Profiles;
+
+use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\Factories\ProfileOptionFactory;
+use Rapkis\Controld\Responses\ProfileOptions;
+
+class Options
+{
+    public function __construct(private readonly PendingRequest $client, private readonly ProfileOptionFactory $option)
+    {
+    }
+
+    public function list(): ProfileOptions
+    {
+        $response = $this->client->get('profiles/options')->json('body.options');
+
+        $result = new ProfileOptions();
+
+        foreach ($response as $option) {
+            $option = $this->option->make($option);
+            $result->put($option->pk, $option);
+        }
+
+        return $result;
+    }
+
+    /**
+     * At the time of writing, ControlD only supports on/of values,
+     * even though ai_malware option does not accept those.
+     * This may change, after this experimental option is finalised.
+     */
+    public function modify(string $profilePk, string $optionPk, bool $enable): bool
+    {
+        $this->client->put("profiles/{$profilePk}/options/{$optionPk}", [
+            'status' => (int) $enable,
+        ]);
+
+        return true;
+    }
+}

--- a/src/Resources/Profiles/Services.php
+++ b/src/Resources/Profiles/Services.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Resources\Profiles;
+
+use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\Entities\ServiceAction;
+use Rapkis\Controld\Factories\ServiceFactory;
+
+class Services
+{
+    public function __construct(private readonly PendingRequest $client, private readonly ServiceFactory $service)
+    {
+    }
+
+    public function list(string $profilePk): \Rapkis\Controld\Responses\Services
+    {
+        $response = $this->client->get("profiles/{$profilePk}/services")->json('body.services');
+
+        $result = new \Rapkis\Controld\Responses\Services();
+
+        foreach ($response as $service) {
+            $service = $this->service->make($service);
+            $result[$service->pk] = $service;
+        }
+
+        return $result;
+    }
+
+    public function modify(string $profilePk, string $servicePk, ServiceAction $action): bool
+    {
+        $this->client->put("profiles/{$profilePk}/services/{$servicePk}", [
+            'do' => $action->do,
+            'status' => (int) $action->status,
+            'via' => $action->via,
+        ]);
+
+        return true;
+    }
+}

--- a/tests/Resources/Profiles/FiltersTest.php
+++ b/tests/Resources/Profiles/FiltersTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Rapkis\Controld\Factories\FilterFactory;
+use Rapkis\Controld\Resources\Profiles\Filters;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('lists native profile filters', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/filters' => Http::response(mockJsonEndpoint('profiles-filters-list-native')),
+    ])->asJson();
+
+    $resource = new Filters(
+        $request,
+        app(FilterFactory::class),
+    );
+
+    $result = $resource->native('profile_pk');
+
+    expect($result)->toBeInstanceOf(\Rapkis\Controld\Responses\Filters::class)
+        ->and($result)->toHaveCount(18);
+});
+
+it('lists third party profile filters', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/filters/external' => Http::response(mockJsonEndpoint('profiles-filters-list-third-party')),
+    ])->asJson();
+
+    $resource = new Filters(
+        $request,
+        app(FilterFactory::class),
+    );
+
+    $result = $resource->thirdParty('profile_pk');
+
+    expect($result)->toBeInstanceOf(\Rapkis\Controld\Responses\Filters::class)
+        ->and($result)->toHaveCount(14);
+});
+
+it('modifies a filter for a profile', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/filters/filter/ads' => Http::response(mockJsonEndpoint('profiles-filters-modify')),
+    ])->asJson();
+
+    $resource = new Filters(
+        $request,
+        $this->createStub(FilterFactory::class),
+    );
+
+    $result = $resource->modify('profile_pk', 'ads', true);
+
+    expect($result)->toHaveCount(3)
+        ->and($result[0])->toEqual('ads')
+        ->and($result[1])->toEqual('iot')
+        ->and($result[2])->toEqual('malware');
+});

--- a/tests/Resources/Profiles/OptionsTest.php
+++ b/tests/Resources/Profiles/OptionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Rapkis\Controld\Factories\ProfileOptionFactory;
+use Rapkis\Controld\Resources\Profiles\Options;
+use Rapkis\Controld\Responses\ProfileOptions;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('lists profile options', function () {
+    $request = Http::fake([
+        'profiles/options' => Http::response(mockJsonEndpoint('profiles-list-options')),
+    ])->asJson();
+
+    $resource = new Options(
+        $request,
+        app(ProfileOptionFactory::class),
+    );
+
+    $result = $resource->list();
+
+    expect($result)->toBeInstanceOf(ProfileOptions::class)
+        ->and($result)->toHaveCount(9);
+});
+
+it('can modify profile option', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/options/option_pk' => Http::response(mockJsonEndpoint('profiles-modify-options')),
+    ])->asJson();
+
+    $resource = new Options(
+        $request,
+        $this->createStub(ProfileOptionFactory::class),
+    );
+
+    expect($resource->modify('profile_pk', 'option_pk', true))->toBeTrue();
+});

--- a/tests/Resources/Profiles/ServicesTest.php
+++ b/tests/Resources/Profiles/ServicesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Rapkis\Controld\Entities\ServiceAction;
+use Rapkis\Controld\Factories\ServiceFactory;
+use Rapkis\Controld\Resources\Profiles\Services;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('lists profile services', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/services' => Http::response(mockJsonEndpoint('profiles-services-list')),
+    ])->asJson();
+
+    $resource = new Services(
+        $request,
+        app(ServiceFactory::class),
+    );
+
+    $result = $resource->list('profile_pk');
+
+    expect($result)->toBeInstanceOf(\Rapkis\Controld\Responses\Services::class)
+        ->and($result)->toHaveCount(4);
+});
+
+it('modifies a service for a profile', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/services/service' => Http::response(mockJsonEndpoint('profiles-services-modify')),
+    ])->asJson();
+
+    $resource = new Services(
+        $request,
+        $this->createStub(ServiceFactory::class),
+    );
+
+    $result = $resource->modify('profile_pk', 'service', new ServiceAction(
+        do: 0,
+        status: true,
+        via: null,
+    ));
+
+    expect($result)->toBeTrue();
+});


### PR DESCRIPTION
- The Profiles.php class was modelled after the documentation endpoints
- But it has grown too much
- Split Profile filters, options and services into the Resources\Profiles namespace to keep things tidy
- Since these resources are still part of the Profiles resource, they are only accessible from the Profiles.php class
- Methods names have been changed due to these alterations
- Modified test cases appropriately