### PR TITLE
Implement Default Rule endpoints

### DIFF
--- a/src/Entities/Service.php
+++ b/src/Entities/Service.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rapkis\Controld\Entities;
 
+use Rapkis\Controld\Responses\Action;
+
 class Service
 {
     public function __construct(

--- a/src/Factories/ActionFactory.php
+++ b/src/Factories/ActionFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rapkis\Controld\Factories;
 
 use Rapkis\Controld\Contracts\Factories\Factory;
-use Rapkis\Controld\Entities\Action;
+use Rapkis\Controld\Responses\Action;
 
 class ActionFactory implements Factory
 {

--- a/src/Resources/Profiles.php
+++ b/src/Resources/Profiles.php
@@ -7,6 +7,7 @@ namespace Rapkis\Controld\Resources;
 use Illuminate\Http\Client\PendingRequest;
 use Rapkis\Controld\Factories\ProfileFactory;
 use Rapkis\Controld\Resources\Profiles\CustomRules;
+use Rapkis\Controld\Resources\Profiles\DefaultRule;
 use Rapkis\Controld\Resources\Profiles\Filters;
 use Rapkis\Controld\Resources\Profiles\Options;
 use Rapkis\Controld\Resources\Profiles\RuleFolders;
@@ -86,5 +87,10 @@ class Profiles
     public function customRules(): CustomRules
     {
         return app(CustomRules::class, ['client' => $this->client]);
+    }
+
+    public function defaultRule(): DefaultRule
+    {
+        return app(DefaultRule::class, ['client' => $this->client]);
     }
 }

--- a/src/Resources/Profiles/CustomRules.php
+++ b/src/Resources/Profiles/CustomRules.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rapkis\Controld\Resources\Profiles;
 
 use Illuminate\Http\Client\PendingRequest;
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\CustomRuleFactory;
+use Rapkis\Controld\Responses\Action;
 
 class CustomRules
 {

--- a/src/Resources/Profiles/DefaultRule.php
+++ b/src/Resources/Profiles/DefaultRule.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Resources\Profiles;
+
+use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\Factories\ActionFactory;
+use Rapkis\Controld\Responses\Action;
+
+class DefaultRule
+{
+    public function __construct(private readonly PendingRequest $client, private readonly ActionFactory $action)
+    {
+    }
+
+    public function list(string $profilePk): ?Action
+    {
+        $response = $this->client->get("profiles/{$profilePk}/default")->json('body.default');
+
+        if (empty($response)) {
+            return null;
+        }
+
+        return $this->action->make($response);
+    }
+
+    public function modify(string $profilePk, Action $action): Action
+    {
+        $response = $this->client->put("profiles/{$profilePk}/default", [
+            'do' => $action->do,
+            'via' => $action->via,
+            'status' => (int) $action->status,
+        ])->json('body.default');
+
+        return $this->action->make($response);
+    }
+}

--- a/src/Resources/Profiles/RuleFolders.php
+++ b/src/Resources/Profiles/RuleFolders.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rapkis\Controld\Resources\Profiles;
 
 use Illuminate\Http\Client\PendingRequest;
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\RuleFolderFactory;
+use Rapkis\Controld\Responses\Action;
 use Rapkis\Controld\Responses\RuleFolder;
 
 class RuleFolders

--- a/src/Resources/Profiles/Services.php
+++ b/src/Resources/Profiles/Services.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rapkis\Controld\Resources\Profiles;
 
 use Illuminate\Http\Client\PendingRequest;
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\ServiceFactory;
+use Rapkis\Controld\Responses\Action;
 
 class Services
 {

--- a/src/Responses/Action.php
+++ b/src/Responses/Action.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rapkis\Controld\Entities;
+namespace Rapkis\Controld\Responses;
 
 use InvalidArgumentException;
 

--- a/src/Responses/CustomRule.php
+++ b/src/Responses/CustomRule.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Rapkis\Controld\Responses;
 
-use Rapkis\Controld\Entities\Action;
-
 class CustomRule
 {
     public function __construct(

--- a/src/Responses/RuleFolder.php
+++ b/src/Responses/RuleFolder.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Rapkis\Controld\Responses;
 
-use Rapkis\Controld\Entities\Action;
-
 class RuleFolder
 {
     public function __construct(

--- a/tests/Factories/ActionFactoryTest.php
+++ b/tests/Factories/ActionFactoryTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\ActionFactory;
+use Rapkis\Controld\Responses\Action;
 
 it('builds an action', function (array $data, Action $expected) {
     expect((new ActionFactory())->make($data))->toEqual($expected);

--- a/tests/Factories/CustomRuleFactoryTest.php
+++ b/tests/Factories/CustomRuleFactoryTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\CustomRuleFactory;
+use Rapkis\Controld\Responses\Action;
 use Rapkis\Controld\Responses\CustomRule;
 
 it('builds a custom rule', function (array $data, CustomRule $expected) {

--- a/tests/Factories/RuleFolderFactoryTest.php
+++ b/tests/Factories/RuleFolderFactoryTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\RuleFolderFactory;
+use Rapkis\Controld\Responses\Action;
 use Rapkis\Controld\Responses\RuleFolder;
 
 it('builds a rule folder', function (array $data, RuleFolder $expected) {

--- a/tests/Factories/ServiceFactoryTest.php
+++ b/tests/Factories/ServiceFactoryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Entities\Service;
 use Rapkis\Controld\Factories\ServiceFactory;
+use Rapkis\Controld\Responses\Action;
 
 it('builds a service', function (array $data, Service $expected) {
     expect((new ServiceFactory())->make($data))->toEqual($expected);

--- a/tests/Mocks/Endpoints/profiles-default-rule-empty.json
+++ b/tests/Mocks/Endpoints/profiles-default-rule-empty.json
@@ -1,0 +1,6 @@
+{
+    "body": {
+        "default": []
+    },
+    "success": true
+}

--- a/tests/Mocks/Endpoints/profiles-default-rule-list.json
+++ b/tests/Mocks/Endpoints/profiles-default-rule-list.json
@@ -1,0 +1,10 @@
+{
+    "body": {
+        "default": {
+            "do": 3,
+            "via": "LOCAL",
+            "status": 1
+        }
+    },
+    "success": true
+}

--- a/tests/Resources/Profiles/CustomRulesTest.php
+++ b/tests/Resources/Profiles/CustomRulesTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\CustomRuleFactory;
 use Rapkis\Controld\Resources\Profiles\CustomRules;
+use Rapkis\Controld\Responses\Action;
 
 beforeEach(function () {
     Http::preventStrayRequests();

--- a/tests/Resources/Profiles/DefaultRuleTest.php
+++ b/tests/Resources/Profiles/DefaultRuleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Rapkis\Controld\Factories\ActionFactory;
+use Rapkis\Controld\Resources\Profiles\DefaultRule;
+use Rapkis\Controld\Responses\Action;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('shows default rule', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/default' => Http::response(mockJsonEndpoint('profiles-default-rule-list')),
+    ])->asJson();
+
+    $resource = new DefaultRule(
+        $request,
+        app(ActionFactory::class),
+    );
+
+    $result = $resource->list('profile_pk');
+
+    expect($result)->toBeInstanceOf(Action::class);
+});
+
+it('shows default rule missing', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/default' => Http::response(mockJsonEndpoint('profiles-default-rule-empty')),
+    ])->asJson();
+
+    $resource = new DefaultRule(
+        $request,
+        $this->createStub(ActionFactory::class),
+    );
+
+    $result = $resource->list('profile_pk');
+
+    expect($result)->toBeNull();
+});
+
+it('can modify profile option', function () {
+    $request = Http::fake([
+        'profiles/profile_pk/default' => Http::response(mockJsonEndpoint('profiles-default-rule-list')),
+    ])->asJson();
+
+    $resource = new DefaultRule(
+        $request,
+        app(ActionFactory::class),
+    );
+
+    $result = $resource->modify('profile_pk', new Action(true, 3, 'LOCAL', null));
+
+    expect($result)->toBeInstanceOf(Action::class);
+});

--- a/tests/Resources/Profiles/RuleFoldersTest.php
+++ b/tests/Resources/Profiles/RuleFoldersTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\RuleFolderFactory;
 use Rapkis\Controld\Resources\Profiles\RuleFolders;
+use Rapkis\Controld\Responses\Action;
 use Rapkis\Controld\Responses\RuleFolder;
 
 beforeEach(function () {

--- a/tests/Resources/Profiles/ServicesTest.php
+++ b/tests/Resources/Profiles/ServicesTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
-use Rapkis\Controld\Entities\Action;
 use Rapkis\Controld\Factories\ServiceFactory;
 use Rapkis\Controld\Resources\Profiles\Services;
+use Rapkis\Controld\Responses\Action;
 
 beforeEach(function () {
     Http::preventStrayRequests();

--- a/tests/Resources/ProfilesTest.php
+++ b/tests/Resources/ProfilesTest.php
@@ -118,3 +118,12 @@ it('accesses custom rules', function () {
 
     expect($resource->customRules())->toBeInstanceOf(Profiles\CustomRules::class);
 });
+
+it('accesses default rule', function () {
+    $resource = new Profiles(
+        $this->createStub(PendingRequest::class),
+        $this->createStub(ProfileFactory::class),
+    );
+
+    expect($resource->defaultRule())->toBeInstanceOf(Profiles\DefaultRule::class);
+});


### PR DESCRIPTION
- Create a new resource DefaultRule.php
- It returns a default rule which is an Action.php class
- Therefore moved the Action.php class to Responses, as it is not a legitimate response object
- No new entities or factories had to be created, everything was reused in DefaultRule.php