### PR TITLE
Implement Devices list endpoint

### DIFF
--- a/src/Entities/DynamicDns.php
+++ b/src/Entities/DynamicDns.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Entities;
+
+class DynamicDns
+{
+    public function __construct(
+        public readonly bool $status,
+        public readonly string $hostname,
+        public readonly ?string $subdomain,
+        public readonly ?string $record,
+    ) {
+    }
+}

--- a/src/Enums/DeviceAnalytics.php
+++ b/src/Enums/DeviceAnalytics.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Enums;
+
+enum DeviceAnalytics: int
+{
+    case OFF = 0;
+    case SOME = 1;
+    case FULL = 2;
+}

--- a/src/Enums/DeviceStatus.php
+++ b/src/Enums/DeviceStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Enums;
+
+enum DeviceStatus: int
+{
+    case PENDING = 0;
+    case ENABLED = 1;
+    case SOFT_DISABLED = 2;
+    case HARD_DISABLED = 3;
+}

--- a/src/Factories/DeviceFactory.php
+++ b/src/Factories/DeviceFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Rapkis\Controld\Factories;
+
+use Illuminate\Support\Arr;
+use Rapkis\Controld\Contracts\Factories\Factory;
+use Rapkis\Controld\Entities\DnsResolver;
+use Rapkis\Controld\Entities\DynamicDns;
+use Rapkis\Controld\Enums\DeviceAnalytics;
+use Rapkis\Controld\Enums\DeviceStatus;
+use Rapkis\Controld\Responses\Device;
+
+class DeviceFactory implements Factory
+{
+    public function make(array $data): Device
+    {
+        if (! empty($data['ddns'])) {
+            $dynamicDns = $this->makeDynamicDns($data['ddns']);
+        }
+
+        if (! empty($data['ddns_ext'])) {
+            $externalDns = $this->makeDynamicDns($data['ddns_ext']);
+        }
+
+        if (! empty($data['legacy_ipv4']) && $data['legacy_ipv4']['status'] === 1) {
+            $legacyIpv4 = new DnsResolver(
+                type: 'legacy_ipv4',
+                values: Arr::wrap($data['legacy_ipv4']['resolver']),
+            );
+        }
+
+        return new Device(
+            pk: $data['PK'],
+            deviceId: $data['device_id'],
+            timestamp: $data['ts'],
+            name: $data['name'],
+            status: DeviceStatus::from((int) $data['status']),
+            learnIp: (bool) $data['learn_ip'],
+            resolvers: $this->makeResolvers($data['resolvers']),
+            profile: (new ProfileFactory())->make($data['profile']),
+            description: $data['description'] ?? '',
+            stats: DeviceAnalytics::tryFrom($data['stats'] ?? null),
+            icon: $data['icon'] ?? null,
+            dynamicDns: $dynamicDns ?? null,
+            dynamicDnsExternal: $externalDns ?? null,
+            legacyIpv4: $legacyIpv4 ?? null,
+            lastActivity: $data['last_activity'] ?? $data['activity'] ?? null,
+            restricted: (bool) ($data['restricted'] ?? false),
+        );
+    }
+
+    private function makeResolvers(array $resolvers): array
+    {
+        $result = [];
+
+        foreach ($resolvers as $name => $resolver) {
+            $result[] = new DnsResolver(
+                type: $name,
+                values: Arr::wrap($resolver)
+            );
+        }
+
+        return $result;
+    }
+
+    private function makeDynamicDns(array $ddns): DynamicDns
+    {
+        return new DynamicDns(
+            status: (bool) $ddns['status'],
+            hostname: $ddns['hostname'] ?? $ddns['host'],
+            subdomain: $ddns['subdomain'] ?? null,
+            record: $ddns['record'] ?? null,
+        );
+    }
+}

--- a/src/Factories/ProfileFactory.php
+++ b/src/Factories/ProfileFactory.php
@@ -12,13 +12,8 @@ class ProfileFactory implements Factory
 {
     public function make(array $data): Profile
     {
-        return new Profile(
-            pk: $data['PK'],
-            updated: $data['updated'],
-            name: $data['name'],
-            disableTtl: $data['disable_ttl'] ?? null,
-            stats: $data['stats'] ?? null,
-            filters: new ProfileFilters(
+        if (! empty($data['profile'])) {
+            $filters = new ProfileFilters(
                 flt: $data['profile']['flt'],
                 cflt: $data['profile']['cflt'],
                 ipflt: $data['profile']['ipflt'],
@@ -27,7 +22,16 @@ class ProfileFactory implements Factory
                 grp: $data['profile']['grp'],
                 opt: $data['profile']['opt'],
                 da: $data['profile']['da'],
-            )
+            );
+        }
+
+        return new Profile(
+            pk: $data['PK'],
+            updated: $data['updated'],
+            name: $data['name'],
+            disableTtl: $data['disable_ttl'] ?? null,
+            stats: $data['stats'] ?? null,
+            filters: $filters ?? null,
         );
     }
 }

--- a/src/Resources/Devices.php
+++ b/src/Resources/Devices.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Resources;
+
+use Illuminate\Http\Client\PendingRequest;
+use Rapkis\Controld\Factories\DeviceFactory;
+
+class Devices
+{
+    public function __construct(
+        private readonly PendingRequest $client,
+        private readonly DeviceFactory $device,
+    ) {
+    }
+
+    public function list(): \Rapkis\Controld\Responses\Devices
+    {
+        $response = $this->client->get('devices')->json('body.devices');
+        $result = new \Rapkis\Controld\Responses\Devices();
+
+        foreach ($response as $device) {
+            $device = $this->device->make($device);
+            $result->put($device->pk, $device);
+        }
+
+        return $result;
+    }
+}

--- a/src/Responses/Device.php
+++ b/src/Responses/Device.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Responses;
+
+use Rapkis\Controld\Entities\DnsResolver;
+use Rapkis\Controld\Entities\DynamicDns;
+use Rapkis\Controld\Enums\DeviceAnalytics;
+use Rapkis\Controld\Enums\DeviceStatus;
+
+class Device
+{
+    /**
+     * @param  array<DnsResolver>  $resolvers
+     */
+    public function __construct(
+        public readonly string $pk,
+        public readonly string $deviceId,
+        public readonly int $timestamp,
+        public readonly string $name,
+        public readonly DeviceStatus $status,
+        public readonly bool $learnIp,
+        public readonly array $resolvers,
+        public readonly Profile $profile,
+        public readonly string $description,
+        public readonly DeviceAnalytics $stats,
+        public readonly ?string $icon,
+        public readonly ?DynamicDns $dynamicDns,
+        public readonly ?DynamicDns $dynamicDnsExternal,
+        public readonly ?DnsResolver $legacyIpv4,
+        public readonly ?int $lastActivity,
+        public readonly bool $restricted,
+    ) {
+    }
+}

--- a/src/Responses/Devices.php
+++ b/src/Responses/Devices.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapkis\Controld\Responses;
+
+use Illuminate\Support\Collection;
+
+class Devices extends Collection
+{
+}

--- a/src/Responses/Profile.php
+++ b/src/Responses/Profile.php
@@ -14,7 +14,7 @@ class Profile
         public readonly string $name,
         public readonly ?int $disableTtl,
         public readonly ?int $stats,
-        public readonly ProfileFilters $filters,
+        public readonly ?ProfileFilters $filters,
     ) {
     }
 }

--- a/tests/Factories/DeviceFactoryTest.php
+++ b/tests/Factories/DeviceFactoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use Rapkis\Controld\Entities\DnsResolver;
+use Rapkis\Controld\Entities\DynamicDns;
+use Rapkis\Controld\Enums\DeviceAnalytics;
+use Rapkis\Controld\Enums\DeviceStatus;
+use Rapkis\Controld\Factories\DeviceFactory;
+use Rapkis\Controld\Responses\Device;
+use Rapkis\Controld\Responses\Profile;
+
+it('builds a device', function (array $data, Device $expected) {
+    expect((new DeviceFactory())->make($data))->toEqual($expected);
+})->with([
+    [
+        [
+            'PK' => 'only_required_fields',
+            'device_id' => 'only_required_fields',
+            'ts' => 111111111,
+            'name' => 'foo-device',
+            'status' => 0, // pending
+            'learn_ip' => 0,
+            'resolvers' => [
+                'uid' => 'resolver_id',
+                'doh' => 'https://dns.controld.com/resolver_id',
+                'dot' => 'resolver_id.dns.controld.com',
+                'v6' => [
+                    '2606:1a40::2',
+                    '22606:1a40:1::2',
+                ],
+            ],
+            'profile' => [
+                'PK' => 'profile_pk',
+                'updated' => 111111111,
+                'name' => 'Foo Profile',
+            ],
+        ],
+        new Device(
+            pk: 'only_required_fields',
+            deviceId: 'only_required_fields',
+            timestamp: 111111111,
+            name: 'foo-device',
+            status: DeviceStatus::PENDING,
+            learnIp: false,
+            resolvers: [
+                new DnsResolver('uid', ['resolver_id']),
+                new DnsResolver('doh', ['https://dns.controld.com/resolver_id']),
+                new DnsResolver('dot', ['resolver_id.dns.controld.com']),
+                new DnsResolver('v6', [
+                    '2606:1a40::2',
+                    '22606:1a40:1::2',
+                ]),
+            ],
+            profile: new Profile(
+                pk: 'profile_pk',
+                updated: 111111111,
+                name: 'Foo Profile',
+                disableTtl: null,
+                stats: null,
+                filters: null,
+            ),
+            description: '',
+            stats: DeviceAnalytics::OFF,
+            icon: null,
+            dynamicDns: null,
+            dynamicDnsExternal: null,
+            legacyIpv4: null,
+            lastActivity: null,
+            restricted: false,
+        ),
+    ],
+    [
+        [
+            'PK' => 'full_info',
+            'device_id' => 'full_info',
+            'ts' => 111111111,
+            'name' => 'foo-device',
+            'status' => 2, // soft disabled
+            'learn_ip' => 0,
+            'resolvers' => [
+                'uid' => 'resolver_id',
+                'doh' => 'https://dns.controld.com/resolver_id',
+                'dot' => 'resolver_id.dns.controld.com',
+                'v6' => [
+                    '2606:1a40::2',
+                    '22606:1a40:1::2',
+                ],
+            ],
+            'profile' => [
+                'PK' => 'profile_pk',
+                'updated' => 111111111,
+                'name' => 'Foo Profile',
+            ],
+            'description' => 'my foo device',
+            'stats' => 2, // full analytics
+            'icon' => 'windows',
+            'ddns' => [
+                'status' => 1,
+                'subdomain' => 'foo',
+                'hostname' => 'foo.controld.live',
+                'record' => '0.0.0.0',
+            ],
+            'ddns_ext' => [
+                'status' => 1,
+                'host' => 'foo.example.com',
+            ],
+            'legacy_ipv4' => [
+                'resolver' => '1.1.1.1',
+                'status' => 1,
+            ],
+            'last_activity' => 999999999,
+            'restricted' => 1,
+        ],
+        new Device(
+            pk: 'full_info',
+            deviceId: 'full_info',
+            timestamp: 111111111,
+            name: 'foo-device',
+            status: DeviceStatus::SOFT_DISABLED,
+            learnIp: false,
+            resolvers: [
+                new DnsResolver('uid', ['resolver_id']),
+                new DnsResolver('doh', ['https://dns.controld.com/resolver_id']),
+                new DnsResolver('dot', ['resolver_id.dns.controld.com']),
+                new DnsResolver('v6', [
+                    '2606:1a40::2',
+                    '22606:1a40:1::2',
+                ]),
+            ],
+            profile: new Profile(
+                pk: 'profile_pk',
+                updated: 111111111,
+                name: 'Foo Profile',
+                disableTtl: null,
+                stats: null,
+                filters: null,
+            ),
+            description: 'my foo device',
+            stats: DeviceAnalytics::FULL,
+            icon: 'windows',
+            dynamicDns: new DynamicDns(
+                status: true,
+                hostname: 'foo.controld.live',
+                subdomain: 'foo',
+                record: '0.0.0.0',
+            ),
+            dynamicDnsExternal: new DynamicDns(
+                status: true,
+                hostname: 'foo.example.com',
+                subdomain: null,
+                record: null,
+            ),
+            legacyIpv4: new DnsResolver(
+                type: 'legacy_ipv4',
+                values: ['1.1.1.1'],
+            ),
+            lastActivity: 999999999,
+            restricted: true,
+        ),
+    ],
+]);

--- a/tests/Factories/ProfileFactoryTest.php
+++ b/tests/Factories/ProfileFactoryTest.php
@@ -91,4 +91,19 @@ it('builds a profile', function (array $data, Profile $expected) {
             )
         ),
     ],
+    [
+        [
+            'PK' => '123test123',
+            'updated' => 111111111,
+            'name' => 'Test',
+        ],
+        new Profile(
+            pk: '123test123',
+            updated: 111111111,
+            name: 'Test',
+            disableTtl: null,
+            stats: null,
+            filters: null,
+        ),
+    ],
 ]);

--- a/tests/Mocks/Endpoints/devices-list.json
+++ b/tests/Mocks/Endpoints/devices-list.json
@@ -1,0 +1,96 @@
+{
+    "body": {
+        "devices": [
+            {
+                "PK": "dummy_pk",
+                "ts": 1669593191,
+                "name": "not-default-device",
+                "device_id": "dummy_device",
+                "status": 1,
+                "learn_ip": 1,
+                "resolvers": {
+                    "uid": "2bmen1byrpr",
+                    "doh": "https://dns.controld.dev/2bmen1byrpr",
+                    "dot": "2bmen1byrpr.dns.controld.dev",
+                    "v4": [
+                        "176.125.239.187",
+                        "176.125.53.187"
+                    ],
+                    "v6": [
+                        "2606:1a40:f000:1e:2c0e:761:3fcf:0",
+                        "2606:1a40:f001:1e:2c0e:761:3fcf:0"
+                    ]
+                },
+                "profile": {
+                    "PK": "4054dvb42i",
+                    "updated": 1670294164,
+                    "name": "Totally Not Default Profile"
+                }
+            },
+            {
+                "PK": "2bmen1byrpr",
+                "ts": 1669593191,
+                "name": "not-default-device",
+                "stats": 2,
+                "device_id": "2bmen1byrpr",
+                "status": 1,
+                "restricted": 0,
+                "learn_ip": 1,
+                "desc": "Comment goes here 2",
+                "ddns": {
+                    "status": 1,
+                    "subdomain": "my-private-subdomain2",
+                    "hostname": "my-private-subdomain2.controld.xyz",
+                    "record": "2607:f0c8:8000:8210:1c7b:b482:1c88:e893"
+                },
+                "ddns_ext": {
+                    "status": 1,
+                    "host": "test.com"
+                },
+                "resolvers": {
+                    "uid": "2bmen1byrpr",
+                    "doh": "https://dns.controld.dev/2bmen1byrpr",
+                    "dot": "2bmen1byrpr.dns.controld.dev",
+                    "v4": [
+                        "176.125.239.187",
+                        "176.125.53.187"
+                    ],
+                    "v6": [
+                        "2606:1a40:f000:1e:2c0e:761:3fcf:0",
+                        "2606:1a40:f001:1e:2c0e:761:3fcf:0"
+                    ]
+                },
+                "legacy_ipv4": {
+                    "resolver": "176.125.239.187",
+                    "status": 1
+                },
+                "profile": {
+                    "PK": "4054dvb42i",
+                    "updated": 1670294164,
+                    "name": "Totally Not Default Profile"
+                }
+            },
+            {
+                "PK": "hl7r34ku0f",
+                "ts": 1670036258,
+                "name": "test-01",
+                "device_id": "hl7r34ku0f",
+                "status": 1,
+                "icon": "desktop-windows",
+                "learn_ip": 1,
+                "resolvers": {
+                    "uid": "hl7r34ku0f",
+                    "doh": "https://dns.controld.dev/hl7r34ku0f",
+                    "dot": "hl7r34ku0f.dns.controld.dev"
+                },
+                "profile": {
+                    "PK": "4054dvb42i",
+                    "updated": 1670294164,
+                    "name": "Totally Not Default Profile"
+                }
+            }
+        ],
+        "activity": false
+    },
+    "success": true
+}

--- a/tests/Resources/DevicesTest.php
+++ b/tests/Resources/DevicesTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Rapkis\Controld\Factories\DeviceFactory;
+use Rapkis\Controld\Resources\Devices;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('lists devices', function () {
+    $request = Http::fake([
+        'devices' => Http::response(mockJsonEndpoint('devices-list')),
+    ])->asJson();
+
+    $resource = new Devices(
+        $request,
+        app(DeviceFactory::class),
+    );
+
+    $result = $resource->list();
+
+    expect($result)->toBeInstanceOf(\Rapkis\Controld\Responses\Devices::class)
+        ->and($result)->toHaveCount(3);
+});


### PR DESCRIPTION
- Created Devices.php and Device.php as responses, because both will be used in other endpoints
- Profile.php and ProfileFactory.php: devices returned in the list contain a profile entry. However, it does not contain the filters that you would receive from the "list profiles" endpoint. Modified the class to make it reusable
- The rest of the implementation is standard as per other endpoints