### PR TITLE
Do not run tests on windows or lowest version composer dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         php: [8.2, 8.1]
         laravel: [10.*]
-        stability: [prefer-lowest, prefer-stable]
+        stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*


### PR DESCRIPTION
- the prefer-lowest stability always fails, due to a broken third party phpunit package nunomaduro/collision: 
```Call to undefined method PHPUnit\Event\Facade::instance() in /home/runner/work/laravel-controld/laravel-controld/vendor/nunomaduro/collision/src/Adapters/Phpunit/Subscribers/EnsurePrinterIsRegisteredSubscriber.php:286```
- GitHub's actions keep getting canceled for unknown reasons. Possibly, due to a lack of resources, therefore the windows platform was dropped to test this out