### PR TITLE
Make all arguments nullable for modifyOrganization method in Organizations resource

### DIFF
--- a/src/Resources/Organizations.php
+++ b/src/Resources/Organizations.php
@@ -85,12 +85,12 @@ class Organizations
     }
 
     public function modifyOrganization(
-        string $name,
-        string $contactEmail,
-        bool $twoFactorAuthenticationRequired,
-        string $statsEndpoint,
-        int $maxUsers,
-        int $maxRouters,
+        string $name = null,
+        string $contactEmail = null,
+        bool $twoFactorAuthenticationRequired = null,
+        string $statsEndpoint = null,
+        int $maxUsers = null,
+        int $maxRouters = null,
         string $address = null,
         string $website = null,
         string $contactName = null,

--- a/tests/Resources/OrganizationsTest.php
+++ b/tests/Resources/OrganizationsTest.php
@@ -86,7 +86,7 @@ it('creates a sub-organization', function () {
     expect($result)->toBeInstanceOf(Organization::class);
 });
 
-it('modifies the organization', function () {
+it('modifies the organization', function (array $arguments) {
     $request = Http::fake([
         'organizations' => Http::response(mockJsonEndpoint('organizations-modify-organization')),
     ])->asJson();
@@ -97,14 +97,24 @@ it('modifies the organization', function () {
         $this->createStub(MemberFactory::class),
     );
 
-    $result = $resource->modifyOrganization(
-        'name',
-        'test@example.com',
-        true,
-        'europe',
-        100,
-        100
-    );
+    $result = $resource->modifyOrganization(...$arguments);
 
     expect($result)->toBeInstanceOf(Organization::class);
-});
+})->with([
+    [
+        [
+            'name',
+            'test@example.com',
+            true,
+            'europe',
+            100,
+            100,
+            'Fake str. 123',
+            'example.com',
+            'Contact Name',
+            '+12345567890',
+            'parent_profile_pk',
+        ],
+        [],
+    ],
+]);


### PR DESCRIPTION
- The endpoint allows any value to be null
- The changes better reflect the endpoint's functionality
- Modified the test case to cover all or no arguments