### PR TITLE
[2.0.0] Proposal: add a wider range of supported PHP versions [8.2-8.4] and add Laravel 12 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -36,7 +36,7 @@ body:
       attributes:
           label: PHP Version
           description: What version of PHP are you running? Please be as specific as possible
-          placeholder: 8.2.0
+          placeholder: 8.4.0
       validations:
           required: true
     - type: input

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4]
-        laravel: [10.*]
+        laravel: [12.*]
         stability: [prefer-stable]
         include:
           - laravel: 12.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4]
+        php: [8.2, 8.3, 8.4]
         laravel: [12.*]
         stability: [prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1]
+        php: [8.4]
         laravel: [10.*]
         stability: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,22 +16,22 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.7",
-        "illuminate/contracts": "^10.0",
+        "php": "^8.4",
+        "guzzlehttp/guzzle": "^7.8",
+        "illuminate/contracts": "^12.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "nunomaduro/collision": "^8.8",
+        "nunomaduro/larastan": "^3.5",
+        "orchestra/testbench": "^10.4",
+        "pestphp/pest": "^3.8",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8",
         "illuminate/contracts": "^12.0",
         "spatie/laravel-package-tools": "^1.14.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   php:
-    image: lorisleiva/laravel-docker:8.2
+    image: lorisleiva/laravel-docker:8.4
     env_file: .env
     working_dir: /var/www/
     volumes:


### PR DESCRIPTION
This change is needed to add support for Laravel 12. It introduces a breaking change due to dependency change, I suggest a major version update.

Change List:
- Added support for 8.2-8.4 PHP versions
- Updated composer dependencies to support Laravel 12
- Updated github workflows to include all supported PHP versions and Laravel 12 framework